### PR TITLE
feat(LoRa): support multiple message formats for different devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The provided Android app is used to gather data from the smartphone's sensors (G
 
 ## Possible Improvements:
 1. ~~Redo device edit/list page to show lora eui if present~~ DONE (31008e87991f8ac9bcb3403117db5f9f2508782d)
-2. Multiple LoRa message structure for different devices (for now they must all use the same) UPDATE: can be done quite easily by editing the common/lora functions server side to take the deviceid, and provide a list of format.
+2. ~~Multiple LoRa message structure for different devices (for now they must all use the same)~~ DONE
 3. As of now, clients are polling to API to retrieve le list of nearby objects reported by other devices. This could be improved by using a messaging system, so clients only receive the necessary information without polling (would improve latency and network usage)
 4. ~~Provide a way to configure a client/device as a stationnary equipement, removing the need for a GPS~~ DONE (7e3b40cd3bfc5fb7e548b04d559a451b1b762fdd)
 5. ~~Live Data persistence: device live data are removed from cache after 1 hour, objects are stored in cache until the app is stopped.~~ DONE (bb2eff6fbd39b616300e1c3c1c5d836a7ba44d3e)

--- a/common/lora.py
+++ b/common/lora.py
@@ -12,19 +12,35 @@ class MissingDataField(Exception):
 class MalformedLoraMessage(Exception):
     pass
 
-# This module's purpose is to serialize the usual json messages into a smaller format
+class UnregisteredDeviceFormat(Exception):
+    pass
+
+# This module's purpose is to serialize the json messages into a smaller format
 # suited for transmission over the LoRa network
 
-# This list of data fields must be a subset of fields available through the client's sensors
-# !! THIS LIST SHOULD BE IDENTICAL IN BOTH THE CLIENT AND THE SERVER !!
-SENSORS_MSG = ['type','msgNumber', 'timestamp', 'latitude', 'longitude', 'altitude', 'azimuth', 'pitch', 'roll', 'speed']
+# data fields that are required in all LoRa messages
+MANDATORY_FIELDS = ['type', 'timestamp','msgNumber']
+
+# This dictionnary is a list of message formats that can be used by LoRa clients
+# !! THIS DICT MUST BE IDENTICAL IN BOTH THE CLIENT AND THE SERVER !!
+#    (or at least the values associated with the format being used)
+MSG_DATA = {1: ['latitude', 'longitude', 'altitude', 'azimuth', 'pitch', 'roll', 'speed']}
+
+# This dictionnary is the mapping between devices and the message format they use.
+DEVICE_MSG_TYPES = {"jetson1": 1,
+                    "test1": 1,
+                    }
 
 # must contain the same elements as `LABELS` in client/spatial_object_perso
 OBJECTS_LABELS = ["background","aeroplane","bicycle","bird","boat","bottle","bus","car",
                 "cat","chair","cow","diningtable","dog","horse","motorbike","person",
                 "pottedplant","sheep","sofa","train","tvmonitor"] + ['unknown']
+
+
+# Same as for device objects, but 
 OBJECT_MSG_HEADER = ['type', 'timestamp']
 OBJECT_ITEM_MSG = ['latitude', 'longitude', 'label', 'id']
+
 
 FIELDS_TYPES = {'type':'H',
                 'msgNumber':'H',
@@ -40,7 +56,24 @@ FIELDS_TYPES = {'type':'H',
                 'id':'i'
                 } 
 
+def getMessageFormat(deviceid):
+    """
+        Returns the list of expected data fields for a particular device
+    """
+
+    message_content_type = DEVICE_MSG_TYPES.get(deviceid, 1)
+    if not message_content_type:
+        message_content_type = 1
+        logger.warning("Unknown message format for LoRa device " + deviceid + ". Using 1 but may be incorrect !")
+
+    return MANDATORY_FIELDS + MSG_DATA[message_content_type]
+
+
 def data_to_lora(data):
+    """
+        Serializes some data to the binary representation to be sent with LoRa.
+    """
+
     if data['type'] == MessageTypes.DEVICE_UPDATE:
         return sample_to_lora(data)
     elif data['type'] == MessageTypes.OBJECT_REPORT:
@@ -50,25 +83,34 @@ def data_to_lora(data):
 
 def sample_to_lora(data):
     """
-        Transform a status update/sensors data message into a minified format suited for the LoRa network
+        Transforms a status update/sensors data message into a minified format suited for the LoRa network
     """
+
+    msg_data_fields = getMessageFormat(data['device-id'])
     try:
         bin = b""
-        for field in SENSORS_MSG:
+        for field in msg_data_fields:
             d = struct.pack(FIELDS_TYPES[field], data[field])
             bin += d
         return bin
     except KeyError:
         raise MissingDataField()
 
-def lora_to_sample(binary):
+
+def lora_to_sample(binary, deviceid):
     """
-        Reverse operation of sample_to_lora. Transform a LoRa message into a easy to use python dict.
+        Reverse operation of sample_to_lora. Transforms a LoRa message into a python dictionary.
+
+        Args:
+        - the binary data : bytes, bytearray
+        - deviceid: str -> the device that sent the message
     """
+
+    msg_expected_fields = getMessageFormat(deviceid)
     try:
         data = {}
         index=0
-        for f in SENSORS_MSG:
+        for f in msg_expected_fields:
             t = FIELDS_TYPES[f]
             size = struct.calcsize(t)
             #print(f, t, size, binary[index:index+size])
@@ -80,6 +122,12 @@ def lora_to_sample(binary):
         raise MalformedLoraMessage(e)
 
 def objects_to_lora(data):
+    """
+        Converts a object report message into its LoRa binary representation
+
+        Args:
+        - data: dict -> the data to be serialized
+    """
     try:
         # preparation
         for o in data['objects']:
@@ -101,6 +149,9 @@ def objects_to_lora(data):
         raise MissingDataField()
 
 def lora_to_objects(binary):
+    """
+        Reverse operation of objects_to_lora
+    """
     try:
         data = {}
         index=0
@@ -131,20 +182,23 @@ def lora_to_objects(binary):
         raise MalformedLoraMessage(e)
     
 def get_message_type(binary):
+    """
+        Returns the message type from a binary LoRa message
+    """
     return struct.unpack(FIELDS_TYPES['type'], binary[0:struct.calcsize(FIELDS_TYPES['type'])])[0]
 
-if __name__=="__main__":
-    object_test_data = json.loads(open("../object.json", 'r').read())
-    sensors_test_data = json.loads(open("../sensors.json", 'r').read())
+# if __name__=="__main__":
+#     object_test_data = json.loads(open("../object.json", 'r').read())
+#     sensors_test_data = json.loads(open("../sensors.json", 'r').read())
 
-    binary = sample_to_lora(sensors_test_data)
-    print(binary, "size", len(binary), type(binary))
+#     binary = sample_to_lora(sensors_test_data)
+#     print(binary, "size", len(binary), type(binary))
 
-    data = lora_to_sample(binary)
-    print(data, len(binary), len(bytes(json.dumps(sensors_test_data), 'utf-8')))
-    print(get_message_type(binary))
+#     data = lora_to_sample(binary)
+#     print(data, len(binary), len(bytes(json.dumps(sensors_test_data), 'utf-8')))
+#     print(get_message_type(binary))
 
-    bin2 = objects_to_lora(object_test_data)
-    print(get_message_type(bin2))
-    print(bin2, len(bin2), len(bytes(json.dumps(object_test_data), 'utf-8')))
-    print(lora_to_objects(bin2))
+#     bin2 = objects_to_lora(object_test_data)
+#     print(get_message_type(bin2))
+#     print(bin2, len(bin2), len(bytes(json.dumps(object_test_data), 'utf-8')))
+#     print(lora_to_objects(bin2))

--- a/common/lora.py
+++ b/common/lora.py
@@ -38,7 +38,7 @@ OBJECTS_LABELS = ["background","aeroplane","bicycle","bird","boat","bottle","bus
 
 
 # Same as for device objects, but 
-OBJECT_MSG_HEADER = ['type', 'timestamp']
+OBJECT_MSG_HEADER = MANDATORY_FIELDS
 OBJECT_ITEM_MSG = ['latitude', 'longitude', 'label', 'id']
 
 

--- a/serveur/Interface.py
+++ b/serveur/Interface.py
@@ -136,7 +136,7 @@ def data_LoRa_handler(message,device):
     if deviceid != None:
         type = lora.get_message_type(message)
         if type == MessageTypes.DEVICE_UPDATE:
-            message = lora.lora_to_sample(message)
+            message = lora.lora_to_sample(message, deviceid)
         elif type == MessageTypes.OBJECT_REPORT:
             message = lora.lora_to_objects(message)
         else:


### PR DESCRIPTION
Adds the support for different devices using different message format, so not all device need to provide the same, fixed, data fields.

Each device is now mapped to a message format (dict), and each message format is a list of data fields to be included in the message.